### PR TITLE
Add Scan and Value methods for JSON (INF-2109)

### DIFF
--- a/types.go
+++ b/types.go
@@ -1409,6 +1409,40 @@ func (s *JSON) Marshal(obj interface{}) error {
 	return nil
 }
 
+// Scan assigns a value from a database driver and implements the sql Scanner interface.
+//
+// See https://pkg.go.dev/database/sql#Scanner
+func (s *JSON) Scan(value interface{}) error {
+	s.isNil = (nil == value)
+	s.isDefined = true
+
+	if s.isNil {
+		s.underlying = nil
+		return nil
+	}
+
+	switch v := value.(type) {
+	case []byte:
+		s.underlying = append(json.RawMessage(nil), v...)
+	case string:
+		s.underlying = json.RawMessage(append([]byte(nil), v...))
+	default:
+		return fmt.Errorf("types.JSON: cannot scan %T", value)
+	}
+
+	return nil
+}
+
+// Value implements the driver Valuer interface.
+//
+// See https://pkg.go.dev/database/sql/driver#Valuer
+func (s JSON) Value() (driver.Value, error) {
+	if s.IsNil() {
+		return nil, nil
+	}
+	return []byte(s.underlying), nil
+}
+
 // RichText is used to represent rich text.
 type RichText struct {
 	underlying string

--- a/types_test.go
+++ b/types_test.go
@@ -11,6 +11,70 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestJSON_Scan(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		var output JSON
+
+		err := output.Scan(nil)
+
+		require.NoError(t, err)
+		assert.True(t, output.IsDefined())
+		assert.True(t, output.IsNil())
+		assert.Nil(t, output.JSON())
+	})
+
+	t.Run("bytes", func(t *testing.T) {
+		input := []byte(`{"a":1}`)
+		var output JSON
+
+		err := output.Scan(input)
+
+		require.NoError(t, err)
+		assert.True(t, output.IsDefined())
+		assert.False(t, output.IsNil())
+		assert.Equal(t, json.RawMessage(`{"a":1}`), output.JSON())
+
+		input[0] = '['
+		assert.Equal(t, json.RawMessage(`{"a":1}`), output.JSON())
+	})
+
+	t.Run("string", func(t *testing.T) {
+		var output JSON
+
+		err := output.Scan(`{"a":1}`)
+
+		require.NoError(t, err)
+		assert.True(t, output.IsDefined())
+		assert.False(t, output.IsNil())
+		assert.Equal(t, json.RawMessage(`{"a":1}`), output.JSON())
+	})
+
+	t.Run("unsupported", func(t *testing.T) {
+		var output JSON
+
+		err := output.Scan(42)
+
+		require.Error(t, err)
+		assert.EqualError(t, err, "types.JSON: cannot scan int")
+	})
+}
+
+func TestJSON_Value(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		output, err := NewJSONFromPtr(nil).Value()
+
+		require.NoError(t, err)
+		assert.Nil(t, output)
+	})
+
+	t.Run("defined", func(t *testing.T) {
+		output, err := NewJSON(json.RawMessage(`{"a":1}`)).Value()
+
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`{"a":1}`), output)
+	})
+}
+
 //nolint:lll
 func TestRichText(t *testing.T) {
 	t.Run("Unmarshal", func(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `sql.Scanner` support for `types.JSON`, including SQL NULL handling and byte-copying from driver buffers
- Add `driver.Valuer` support so nil JSON writes as SQL NULL and non-nil JSON writes as bytes
- Add focused tests for scanning nil, bytes, strings, unsupported values, and driver values

## Testing
- `go test ./...`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-2109](https://linear.app/meitner-se/issue/INF-2109/typesjson-missing-scanvalue-methods-fails-on-null-columns)

<div><a href="https://cursor.com/agents/bc-00ad16a7-560e-431d-8e5b-e64461da3def"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00ad16a7-560e-431d-8e5b-e64461da3def"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

