### PR TITLE
Migrate GitHub Actions workflows to Node 24 (INF-2947)

### DIFF
--- a/.github/workflows/go-modules.yaml
+++ b/.github/workflows/go-modules.yaml
@@ -9,9 +9,6 @@ on:
     paths:
       - '**'
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   go-mod-tidy:
     runs-on: ubuntu-24.04

--- a/.github/workflows/go-modules.yaml
+++ b/.github/workflows/go-modules.yaml
@@ -9,18 +9,21 @@ on:
     paths:
       - '**'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   go-mod-tidy:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Go Mod Tidy
         run: go mod tidy
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           cache: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   release-tag:
     runs-on: ubuntu-24.04
@@ -19,7 +22,7 @@ jobs:
       GH_DEBUG: api
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Fetch all history
           filter: tree:0  # "Treeless clones" filter

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,9 +11,6 @@ on:
 permissions:
   contents: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   release-tag:
     runs-on: ubuntu-24.04

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,9 +5,6 @@ on:
     paths:
       - '**'
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,9 @@ on:
     paths:
       - '**'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
   pull-requests: write
@@ -15,10 +18,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           cache: true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Bump `actions/checkout` from v4 to v5 in all workflows.
- Bump `actions/setup-go` from v5 to v6 in Go workflows.
- Removed the temporary `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env var after the required trial run.

## Verification
- `python3` parsed all workflow YAML files.
- `go test ./...` passed locally.
- Trial push commit `bacbdb9` ran `Go Modules` and `Test` with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`; both passed.
- Inspected trial run logs/annotations for `Go Modules` (26154450439) and `Test` (26154450514); found zero `Node.js 20 actions are deprecated` warnings.
- Final push commit `b20c646` ran `Go Modules` (26154513661) and `Test` (26154513733); both passed, with no Node 20 warnings or annotations.

## Notes
- `.github/workflows/release.yaml` is `main`-only, so it did not run on the branch push; its sole JavaScript action was bumped from `actions/checkout@v4` to `actions/checkout@v5`.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-2947](https://linear.app/meitner-se/issue/INF-2947/migrate-github-actions-workflows-from-node-20-to-node-24)

<div><a href="https://cursor.com/agents/bc-387503d1-885d-439e-86d9-5a6e40047d98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-387503d1-885d-439e-86d9-5a6e40047d98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

